### PR TITLE
adding haproxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Pull the NextCloud image, tag it, and push it to your local registry
 `docker tag nextcloud:21.0.0 localhost:5000/nextcloud:21.0.0`  
 `docker push localhost:5000/nextcloud:21.0.0`  
 
+# HAProxy
+At this time you'll need to manually create the haproxy.cfg file and put it on the nextcloud_haproxy volume.  Also required is the `errors` folder which contains the 400's and 500's error messages.  This can be pulled from another running haproxy container.  Alternatively you can make your own image and copy in the cfg file.  This seems undesirable to me.
+`docker pull haproxy:2.3`
+`docker tag haproxy:2.3 localhost:5000/haproxy:2.3`
+`docker push localhost:5000/haproxy:2.3`
+
 # Create new Stack in Portainer
 After you have Portainer setup and configured how you want it:  
 1. Create a new Stack  
@@ -21,7 +27,7 @@ After you have Portainer setup and configured how you want it:
     ii. db: MYSQL_PASSWORD  
     iii. app: MYSQL_PASSWORD  
     iv. app: NEXTCLOUD_ADMIN_PASSWORD  
-  b. Modify the upload limit as needed  
+  b. Modify the upload limit as needed (2G is probably fine for must use cases, I have 12G because I need to upload large ISO files)  
   c. Change the database name and user names as desired  
 5. Using the "Web Editor" Build method, paste in the modified docker-compose.yml  
 6. Click the `Deploy the Stack` button at the bottom.  

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Pull the NextCloud image, tag it, and push it to your local registry
 `docker push localhost:5000/nextcloud:21.0.0`  
 
 # HAProxy
-At this time you'll need to manually create the haproxy.cfg file and put it on the nextcloud_haproxy volume.  Also required is the `errors` folder which contains the 400's and 500's error messages.  This can be pulled from another running haproxy container.  Alternatively you can make your own image and copy in the cfg file.  This seems undesirable to me.  
+At this time you'll need to manually create the haproxy.cfg file and put it on the nextcloud_haproxy volume.  You'll need to change the line to reflect your domain replacing the `-i localhost` with `-i yourdomain.com`.  
+Also required is the `errors` folder which contains the 400's and 500's error messages.  This can be pulled from another running haproxy container.   
+Alternatively you can make your own image and copy in the cfg file.  This seems undesirable to me.  
 `docker pull haproxy:2.3`  
 `docker tag haproxy:2.3 localhost:5000/haproxy:2.3`  
 `docker push localhost:5000/haproxy:2.3`

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Pull the NextCloud image, tag it, and push it to your local registry
 `docker push localhost:5000/nextcloud:21.0.0`  
 
 # HAProxy
-At this time you'll need to manually create the haproxy.cfg file and put it on the nextcloud_haproxy volume.  Also required is the `errors` folder which contains the 400's and 500's error messages.  This can be pulled from another running haproxy container.  Alternatively you can make your own image and copy in the cfg file.  This seems undesirable to me.
-`docker pull haproxy:2.3`
-`docker tag haproxy:2.3 localhost:5000/haproxy:2.3`
+At this time you'll need to manually create the haproxy.cfg file and put it on the nextcloud_haproxy volume.  Also required is the `errors` folder which contains the 400's and 500's error messages.  This can be pulled from another running haproxy container.  Alternatively you can make your own image and copy in the cfg file.  This seems undesirable to me.  
+`docker pull haproxy:2.3`  
+`docker tag haproxy:2.3 localhost:5000/haproxy:2.3`  
 `docker push localhost:5000/haproxy:2.3`
 
 # Create new Stack in Portainer

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # nextcloud_docker
 Dockerized NextCloud https://github.com/nextcloud/docker  
-This repo is for setting up NextCloud in Docker containers using Portainer-CE. 
+This repo is for setting up NextCloud in Docker containers using Portainer-CE.  
+At this time this example is just using HTTP (no S).  So don't use it over the Internet because your password will be exposed as well as your files and data.  You may want to add on <a href="https://letsencrypt.org/how-it-works/">Let's Encrypt</a> or another SSL certificate provider.  And make the necessary changes to the HAProxy services.
 
 # Pre-requisites
 You may want to follow my setup for Docker and Portainer with a local registry.  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,13 @@
 version: '2'
 
+volumes:
+  nextcloud_db:
+  nextcloud_:
+  nextcloud_data:
+  nextcloud_apps:
+  nextcloud_config:
+  nextcloud_haproxy:
+  
 services:
   db:
     image: localhost:5000/mariadb:10.2.37
@@ -16,8 +24,6 @@ services:
   app:
     image: localhost:5000/nextcloud:21.0.0-apache
     restart: always
-    ports:
-      - 8080:80
     links:
       - db
     volumes:
@@ -33,3 +39,13 @@ services:
       - NEXTCLOUD_ADMIN_USER=ncadmin
       - NEXTCLOUD_ADMIN_PASSWORD=12qw34er
       - PHP_UPLOAD_LIMIT=12G
+
+  haproxy:
+    image: localhost:5000/haproxy:2.3
+    restart: always
+    ports:
+      - 80:80
+    links:
+      - app
+    volumes:
+      - nextcloud_haproxy:/usr/local/etc/haproxy

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -1,0 +1,25 @@
+global
+    log 127.0.0.1 local0
+    maxconn 4096
+
+defaults
+    log global
+    mode http
+    option httplog
+    option dontlognull
+    retries 3
+    option redispatch
+    maxconn 2000
+    timeout connect 5000
+    timeout client 50000
+    timeout server 50000
+
+frontend http-in
+    bind *:80
+    acl nextcloud-frontend hdr(host) -i localhost
+    use_backend nextcloud-backend if nextcloud-frontend
+
+backend nextcloud-backend
+    balance roundrobin
+    option http-server-close
+    server nextcloud-server-1 app:80 check


### PR DESCRIPTION
HAProxy needs a config file to start.
Example:
```
global
    log 127.0.0.1 local0
    maxconn 4096

defaults
    log global
    mode http
    option httplog
    option dontlognull
    retries 3
    option redispatch
    maxconn 2000
    timeout connect 5000
    timeout client 50000
    timeout server 50000

frontend http-in
    bind *:80
    acl nextcloud-frontend hdr(host) -i localhost
    use_backend nextcloud-backend if nextcloud-frontend

backend nextcloud-backend
    balance roundrobin
    option http-server-close
    server nextcloud-server-1 app:80 check
```